### PR TITLE
Fix Unicode escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var detection = 'class ಠ_ಠ extends Array{constructor(j=`a`,...c){const q=(({u: e})=>{return {[`${c}`]:Symbol(j)};})({});super(j,q,...c)}}new Promise(f=>{const a=function*(){return "\u{20BB7}".match(/./u)[0].length===2||!0};for (let z of a()){const [x,y,w,k]=[new Set(),new WeakSet(),new Map(), new WeakMap()];break}f(new Proxy({},{get:(h,i) =>i in h ?h[i]:"j".repeat(0o2)}))}).then(t => new ಠ_ಠ(t.d))'
+var detection = 'class ಠ_ಠ extends Array{constructor(j=`a`,...c){const q=(({u: e})=>{return {[`${c}`]:Symbol(j)};})({});super(j,q,...c)}}new Promise(f=>{const a=function*(){return "\\u{20BB7}".match(/./u)[0].length===2||!0};for (let z of a()){const [x,y,w,k]=[new Set(),new WeakSet(),new Map(), new WeakMap()];break}f(new Proxy({},{get:(h,i) =>i in h ?h[i]:"j".repeat(0o2)}))}).then(t => new ಠ_ಠ(t.d))'
 
 var result
 


### PR DESCRIPTION
This module is failing in IE9 with an "Expected hexadecimal digit" error. After some digging I found that it's because the Unicode character isn't properly escaped. Changing `\u` to `\\u` solves it.

You can check that other browsers still work by checking both of these return `true`:
`eval('"\\u{20BB7}".match(/./u)[0].length===2')`
`eval('"\u{20BB7}".match(/./u)[0].length===2')`